### PR TITLE
Adding oled dep through github to build.gradle.  Fixing deploy.sh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://jitpack.io"}
+
     flatDir {
         dirs 'libs'
     }
@@ -45,7 +47,7 @@ dependencies {
 
     compile "com.pi4j:pi4j-core:1.2-SNAPSHOT"
     compile "org.projectlombok:lombok:1.18.4"
-    compile name: "oled-core-2.0"
+    implementation "com.github.fauxpark:oled-core:v2.0"
 }
 
 shadowJar {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # TODO, use a key-file rather than requiring manual authentication
 ./gradlew build \
-  && rsync -avzhe ssh ./build/libs/pi-naut-1.0.0-SNAPSHOT-all.jar pi@raspberrypi.local/opt/pi-naut/github-notify.jar \
-  && ssh pi@raspberrypi.local "sudo service restart github-notify"
+  && rsync -avzhe ssh ./build/libs/pi-naut-1.0.0-SNAPSHOT-all.jar pi@raspberrypi.local:/opt/pi-naut/github-notify.jar \
+  && ssh pi@raspberrypi.local "sudo systemctl restart github-notify"


### PR DESCRIPTION
Tested with that 'test-this' branch.  Deploys and service starts but getting null pointers but I assume this is just a problem with the quick changes made at work to get a quick test running. 

`Feb 23 07:29:14 raspberrypi java[6614]: 07:29:14.987 [pool-1-thread-2] ERROR i.m.s.DefaultTaskExceptionHandler - Error invoking sche
Feb 23 07:29:14 raspberrypi java[6614]: java.lang.NullPointerException: null
Feb 23 07:29:14 raspberrypi java[6614]:         at net.fauxpark.oled.transport.I2CTransport.command(I2CTransport.java:86)
Feb 23 07:29:14 raspberrypi java[6614]:         at net.fauxpark.oled.SSD1306.command(SSD1306.java:470)
Feb 23 07:29:14 raspberrypi java[6614]:         at net.fauxpark.oled.SSD1306.display(SSD1306.java:169)
Feb 23 07:29:14 raspberrypi java[6614]:         at pi.naut.gpio.display.ssd1306.SSD1306Display.displayLayout(SSD1306Display.java:50)
Feb 23 07:29:14 raspberrypi java[6614]:         at pi.naut.github.GitHubJob.playground(GitHubJob.java:58)
Feb 23 07:29:14 raspberrypi java[6614]:         at pi.naut.github.$GitHubJobDefinition$$exec1.invokeInternal(Unknown Source)
Feb 23 07:29:14 raspberrypi java[6614]:         at io.micronaut.context.AbstractExecutableMethod.invoke(AbstractExecutableMethod.jav
Feb 23 07:29:14 raspberrypi java[6614]:         at io.micronaut.inject.DelegatingExecutableMethod.invoke(DelegatingExecutableMethod.
Feb 23 07:29:14 raspberrypi java[6614]:         at io.micronaut.scheduling.processor.ScheduledMethodProcessor.lambda$process$5(Sched
Feb 23 07:29:14 raspberrypi java[6614]:         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
Feb 23 07:29:14 raspberrypi java[6614]:         at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
Feb 23 07:29:14 raspberrypi java[6614]:         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(S
Feb 23 07:29:14 raspberrypi java[6614]:         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Schedule
Feb 23 07:29:14 raspberrypi java[6614]:         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
Feb 23 07:29:14 raspberrypi java[6614]:         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
Feb 23 07:29:14 raspberrypi java[6614]:         at java.lang.Thread.run(Thread.java:748)
`