### PR TITLE
Fixed Screen Display

### DIFF
--- a/src/main/java/pi/naut/gpio/display/ssd1306/SSD1306Display.java
+++ b/src/main/java/pi/naut/gpio/display/ssd1306/SSD1306Display.java
@@ -33,6 +33,10 @@ public class SSD1306Display implements Display {
 
 	@Override
 	public void clearDisplay() {
+		if (!controller.isInitialised()) {
+			System.out.println("STARTUP!");
+			controller.startup(false);
+		}
 		controller.clear();
 		controller.display();
 	}
@@ -48,10 +52,12 @@ public class SSD1306Display implements Display {
 		layout.bufferLayoutTo(controller);
 		applyListenerConfiguration(layout);
 		controller.display();
+		controller.getGraphics().circle(4, 4, 32);
 	}
 
 	@Override
 	public void displayTimedlayout(Layout layout, long layoutDurationInMs) {
+
 		byte[] buffer = controller.getBuffer();
 		displayLayout(layout);
 		Timer timer = new Timer();


### PR DESCRIPTION
So the reason the screen was not working was the Display needs to be initialized first.  Running the external Adafruit Python examples would initialize the display (incorrectly mind you) and would thus cause the Java code to work)

We can talk about a better place to put this though.  Just wanting to get it in there so we know we need to do it.